### PR TITLE
relax pkg rules, fixes #18

### DIFF
--- a/commands/check.js
+++ b/commands/check.js
@@ -58,7 +58,7 @@ var checkPackage = function(argv, done) {
     name: Joi.string().min(1).max(30).regex(/^[a-zA-Z0-9][a-zA-Z0-9\.\-_]*$/).required(),
     version: Joi.string().regex(/^[0-9]+\.[0-9]+[0-9+a-zA-Z\.\-]+$/).required(),
     description: Joi.string().max(80).required(),
-    license: Joi.string().alphanum().max(10).required(),
+    license: Joi.string().max(20).required(),
     homepage: Joi.string().uri({
       scheme: ['http', 'https']
     }).required(),
@@ -71,7 +71,7 @@ var checkPackage = function(argv, done) {
     }),
     bin: Joi.object().optional(),
     scripts: Joi.object().optional(),
-    bugs: Joi.object().required(),
+    bugs: Joi.alternatives().try(Joi.string(), Joi.object()).required(),
     author: Joi.string().required(),
     dependencies: Joi.object().required(),
     devDependencies: Joi.object().required()


### PR DESCRIPTION
`bugs` does not have to be an object, can be string.
`license` does not have to be alpha-numeric, e.g. `Apache-2.0`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongodb-js/mj/21)

<!-- Reviewable:end -->
